### PR TITLE
Update Libraries for Enhanced TLD Support and Version Upgrades

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,17 @@
 module github.com/lissy93/who-dat
 
-go 1.16
+go 1.20
 
 require (
-	github.com/json-iterator/go v1.1.9
-	github.com/likexian/whois-go v1.6.0
-	github.com/likexian/whois-parser-go v1.14.2
+	github.com/json-iterator/go v1.1.12
+	github.com/likexian/whois v1.15.1
+	github.com/likexian/whois-parser v1.24.10
+)
+
+require (
+	github.com/likexian/gokit v0.25.13 // indirect
+	github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 // indirect
+	github.com/modern-go/reflect2 v1.0.2 // indirect
+	golang.org/x/net v0.14.0 // indirect
+	golang.org/x/text v0.12.0 // indirect
 )

--- a/lib/multi.go
+++ b/lib/multi.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"time"
 
-	"github.com/likexian/whois-go"
-	whoisparser "github.com/likexian/whois-parser-go"
+	"github.com/likexian/whois"
+	whoisparser "github.com/likexian/whois-parser"
 )
 
 func GetMultiWhois(ctx context.Context, domains []string) ([]whoisparser.WhoisInfo, error) {

--- a/lib/whois.go
+++ b/lib/whois.go
@@ -1,8 +1,8 @@
 package lib
 
 import (
-	"github.com/likexian/whois-go"
-	whoisparser "github.com/likexian/whois-parser-go"
+	"github.com/likexian/whois"
+	whoisparser "github.com/likexian/whois-parser"
 )
 
 // GetWhois does a WHOIS lookup for a supplied domain


### PR DESCRIPTION
- Upgraded Go from 1.16 to 1.20.
- Updated json-iterator/go from v1.1.9 to v1.1.12.

Changed Libraries for Compatibility and Updates:
- Replaced whois-go v1.6.0 with whois v1.15.1.
- Replaced whois-parser-go v1.14.2 with whois-parser v1.24.10. Reason: Older versions ("-go") are outdated and lack support for some TLDs, as reported in Issue: https://github.com/Lissy93/who-dat/issues/2.