### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
         <p>Free & Open Source WHOIS Lookup Service</p>
       </div>
       <nav>
-        <a href="/docs.html">Public API</a>
+        <a href="https://who-dat.as93.net/docs.html">Public API</a>
         <a href="https://github.com/Lissy93/who-dat#deployment">Self-Hosting</a>
         <a href="https://github.com/Lissy93/who-dat">GitHub</a>
       </nav>


### PR DESCRIPTION
Added full URI for Public API docs - https://who-dat.as93.net/docs.html

As who-dat runs as a lone process, the docs link on a self-hosted instance breaks as it was relative.