### PR TITLE
Fallback RDAP seeds for TLDs not submitted to IANA

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -63,7 +63,7 @@ If you're self-hosting (recommended) then replace this with your own base URL.
 - **Success Response**:
   - **Code**: 200 (the lookup succeeded, whether or not the domain is registered)
   - **Content**: Normalized WHOIS/RDAP data as JSON; the `isRegistered` field indicates registration status.
-- **Error Response** (uniform envelope: `{ "error": { "code", "message", "query" } }`):
+- **Error Response** (uniform envelope: `{ "error": { "code", "message", "query" } }`, plus `source`, `server`, and `detail` when known):
   - **400** - invalid or unparseable domain
   - **429** - rate limited (includes a `Retry-After` header)
   - **501** - no RDAP or WHOIS source for that TLD

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,9 @@ jobs:
       docker: ${{ steps.filter.outputs.docker }}
       workflows: ${{ steps.filter.outputs.workflows }}
     steps:
-      - name: 🛎️ Checkout
+      - name: Checkout
         uses: actions/checkout@v4
-      - name: 🔎 Filter paths
+      - name: Filter paths
         id: filter
         uses: dorny/paths-filter@v3
         with:
@@ -50,13 +50,13 @@ jobs:
     if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
     steps:
-      - name: 🛎️ Checkout
+      - name: Checkout
         uses: actions/checkout@v4
-      - name: 🐹 Set up Go
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - name: 🎨 Check gofmt
+      - name: Check gofmt
         run: |
           unformatted=$(gofmt -l .)
           if [ -n "$unformatted" ]; then
@@ -72,49 +72,49 @@ jobs:
     if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
     steps:
-      - name: 🛎️ Checkout
+      - name: Checkout
         uses: actions/checkout@v4
-      - name: 🐹 Set up Go
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - name: 🔬 Run go vet
+      - name: Run go vet
         run: go vet ./...
 
   # staticcheck: the de-facto Go linter (bugs, simplifications, style).
   lint:
-    name: 🧹 Lint (staticcheck)
+    name: 🧼 Static check
     needs: changes
     if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
     steps:
-      - name: 🛎️ Checkout
+      - name: Checkout
         uses: actions/checkout@v4
-      - name: 🐹 Set up Go
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - name: 🧹 Run staticcheck
+      - name: Run staticcheck
         run: |
           go install honnef.co/go/tools/cmd/staticcheck@latest
           staticcheck ./...
 
   # go test with the race detector.
   test:
-    name: ✅ Test
+    name: 🧪 Test
     needs: changes
     if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
     steps:
-      - name: 🛎️ Checkout
+      - name: Checkout
         uses: actions/checkout@v4
-      - name: 🐹 Set up Go
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - name: ✅ Run tests
+      - name: Run tests
         run: go test -race -shuffle=on -coverprofile=coverage.out ./...
-      - name: 📊 Coverage summary
+      - name: Coverage summary
         run: go tool cover -func=coverage.out | tail -1
 
   # Ensure the whole module compiles.
@@ -124,29 +124,29 @@ jobs:
     if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
     steps:
-      - name: 🛎️ Checkout
+      - name: Checkout
         uses: actions/checkout@v4
-      - name: 🐹 Set up Go
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - name: 🔨 Build all packages
+      - name: Build all packages
         run: go build ./...
 
   # go.mod / go.sum must be tidy.
   tidy:
-    name: 📦 Tidy
+    name: 🧹 Tidy
     needs: changes
     if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
     steps:
-      - name: 🛎️ Checkout
+      - name: Checkout
         uses: actions/checkout@v4
-      - name: 🐹 Set up Go
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - name: 📦 Verify go mod tidy
+      - name: Verify go mod tidy
         run: |
           go mod tidy
           git diff --exit-code -- go.mod go.sum \
@@ -159,13 +159,13 @@ jobs:
     if: needs.changes.outputs.go == 'true'
     runs-on: ubuntu-latest
     steps:
-      - name: 🛎️ Checkout
+      - name: Checkout
         uses: actions/checkout@v4
-      - name: 🐹 Set up Go
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
           go-version-file: go.mod
-      - name: 🛡️ Run govulncheck
+      - name: Run govulncheck
         run: |
           go install golang.org/x/vuln/cmd/govulncheck@latest
           govulncheck ./...
@@ -177,18 +177,18 @@ jobs:
     if: needs.changes.outputs.docker == 'true'
     runs-on: ubuntu-latest
     steps:
-      - name: 🛎️ Checkout
+      - name: Checkout
         uses: actions/checkout@v4
-      - name: 🔧 Set up Docker Buildx
+      - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: 🔨 Build image
+      - name: Build image
         uses: docker/build-push-action@v6
         with:
           context: .
           load: true
           tags: who-dat:ci
           provenance: false
-      - name: 💨 Smoke test
+      - name: Smoke test
         run: |
           docker run -d --name wd-ci -p 8080:8080 who-dat:ci
           for i in $(seq 1 20); do
@@ -212,9 +212,9 @@ jobs:
     if: needs.changes.outputs.workflows == 'true'
     runs-on: ubuntu-latest
     steps:
-      - name: 🛎️ Checkout
+      - name: Checkout
         uses: actions/checkout@v4
-      - name: 🤖 Run actionlint
+      - name: Run actionlint
         run: |
           bash <(curl --proto '=https' --tlsv1.2 -sSf \
             https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
@@ -225,11 +225,11 @@ jobs:
     name: 🔑 Secret Scan
     runs-on: ubuntu-latest
     steps:
-      - name: 🛎️ Checkout
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: 🔑 Run gitleaks
+      - name: Run gitleaks
         uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cmd/tldcheck/main.go
+++ b/cmd/tldcheck/main.go
@@ -69,7 +69,7 @@ func main() {
 
 	httpClient := &http.Client{
 		Timeout:   *timeout + 5*time.Second,
-		Transport: &http.Transport{TLSClientConfig: rdap.TLSConfig()},
+		Transport: &http.Transport{TLSClientConfig: rdap.TLSConfig(), ForceAttemptHTTP2: true},
 	}
 
 	listCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/lissy93/who-dat
 
 go 1.25.0
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	github.com/likexian/whois v1.15.6

--- a/internal/lookup/lookup.go
+++ b/internal/lookup/lookup.go
@@ -4,6 +4,7 @@ package lookup
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/lissy93/who-dat/internal/cache"
 	"github.com/lissy93/who-dat/internal/domain"
@@ -43,7 +44,9 @@ func (s *Service) Lookup(ctx context.Context, n domain.Name) (*model.Result, err
 
 	r, err := s.rdap.Lookup(ctx, n)
 	if errors.Is(err, srcerr.ErrNoSource) {
-		r, err = s.whois.Lookup(ctx, n)
+		if r, err = s.whois.Lookup(ctx, n); err != nil {
+			err = fmt.Errorf("no rdap server registered for .%s; fell back to %w", n.TLD, err)
+		}
 	}
 	if err != nil {
 		return nil, err

--- a/internal/lookup/lookup_test.go
+++ b/internal/lookup/lookup_test.go
@@ -3,6 +3,7 @@ package lookup
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 	"time"
 
@@ -46,6 +47,19 @@ func TestLookupFallsBackToWHOIS(t *testing.T) {
 	}
 	if got == nil || whois.calls != 1 {
 		t.Fatalf("expected WHOIS fallback; whois.calls=%d", whois.calls)
+	}
+}
+
+func TestLookupFallbackErrorIsAnnotated(t *testing.T) {
+	rdap := &fakeSource{err: srcerr.ErrNoSource}
+	whois := &fakeSource{err: srcerr.ErrTimeout}
+	_, err := NewService(rdap, whois, nil).Lookup(context.Background(), testName)
+
+	if !errors.Is(err, srcerr.ErrTimeout) {
+		t.Fatalf("err = %v, want ErrTimeout preserved through annotation", err)
+	}
+	if !strings.Contains(err.Error(), "no rdap server registered for .com") {
+		t.Errorf("err = %q, want the missing-RDAP annotation", err)
 	}
 }
 

--- a/internal/rdap/bootstrap.go
+++ b/internal/rdap/bootstrap.go
@@ -28,6 +28,7 @@ var seeds = map[string][]string{
 	"af":               {"https://whois.nic.af/"}, // whois by name, rdap by nature
 	"ag":               {"https://rdap.identitydigital.services/rdap/"},
 	"arpa":             {"https://rdap.iana.org/"},
+	"aw":               {"https://rdap.nic.aw/"},
 	"bh":               {"https://rdap.centralnic.com/bh/"},
 	"bw":               {"https://rdap.nic.net.bw/"},
 	"bz":               {"https://rdap.identitydigital.services/rdap/"},
@@ -40,6 +41,7 @@ var seeds = map[string][]string{
 	"gi":               {"https://rdap.identitydigital.services/rdap/"},
 	"gl":               {"https://rdap.centralnic.com/gl/"},
 	"io":               {"https://rdap.identitydigital.services/rdap/"},
+	"iq":               {"https://rdap.reg.iq/rdap/"},
 	"ki":               {"https://rdap.coccaregistry.org/"},
 	"kz":               {"https://rdap.nic.kz/"},
 	"lc":               {"https://rdap.identitydigital.services/rdap/"},
@@ -64,6 +66,7 @@ var seeds = map[string][]string{
 	"ve":               {"https://rdap.nic.ve/rdap/"},
 	"vu":               {"https://rdap.dnrs.vu/"},
 	"ws":               {"https://rdap.website.ws/"},
+	"xn--kprw13d":      {"https://ccrdap.twnic.tw/taiwan/"},               // Taiwan IDN, twin of IANA-listed xn--kpry57d
 	"xn--mgbcpq6gpa1a": {"https://rdap.centralnic.com/xn--mgbcpq6gpa1a/"}, // Bahrain IDN
 	"xn--p1ai":         {"https://cctld.ru/tci-ripn-rdap/"},               // Cyrillic .rf
 }

--- a/internal/rdap/bootstrap.go
+++ b/internal/rdap/bootstrap.go
@@ -19,6 +19,55 @@ const bootstrapURL = "https://data.iana.org/rdap/dns.json"
 // bootstrapTTL is how long a fetched registry is trusted before re-fetching.
 const bootstrapTTL = 24 * time.Hour
 
+// seeds covers registries that run perfectly good RDAP but never told IANA
+// (rdap.org calls these "stealth" servers). Every entry is verified against a
+// live domain before landing here; add one line per missing TLD. If a TLD
+// later shows up in the IANA registry, that entry wins and the seed retires.
+var seeds = map[string][]string{
+	"ac":               {"https://rdap.identitydigital.services/rdap/"},
+	"af":               {"https://whois.nic.af/"}, // whois by name, rdap by nature
+	"ag":               {"https://rdap.identitydigital.services/rdap/"},
+	"arpa":             {"https://rdap.iana.org/"},
+	"bh":               {"https://rdap.centralnic.com/bh/"},
+	"bw":               {"https://rdap.nic.net.bw/"},
+	"bz":               {"https://rdap.identitydigital.services/rdap/"},
+	"ch":               {"https://rdap.nic.ch/"},
+	"ci":               {"https://rdap.nic.ci/"},
+	"co":               {"https://rdap.registry.co/co/"},
+	"de":               {"https://rdap.denic.de/"},
+	"dm":               {"https://rdap.dmdomains.dm/rdap/"},
+	"ga":               {"https://rdap.nic.ga/"},
+	"gi":               {"https://rdap.identitydigital.services/rdap/"},
+	"gl":               {"https://rdap.centralnic.com/gl/"},
+	"io":               {"https://rdap.identitydigital.services/rdap/"},
+	"ki":               {"https://rdap.coccaregistry.org/"},
+	"kz":               {"https://rdap.nic.kz/"},
+	"lc":               {"https://rdap.identitydigital.services/rdap/"},
+	"li":               {"https://rdap.nic.li/"},
+	"me":               {"https://rdap.identitydigital.services/rdap/"},
+	"mn":               {"https://rdap.identitydigital.services/rdap/"},
+	"mr":               {"https://rdap.nic.mr/"},
+	"my":               {"https://rdap.mynic.my/rdap/"},
+	"mz":               {"https://rdap.nic.mz/"},
+	"om":               {"https://rdap.registry.om/"},
+	"pr":               {"https://rdap.identitydigital.services/rdap/"},
+	"ru":               {"https://cctld.ru/tci-ripn-rdap/"},
+	"sb":               {"https://rdap.nic.sb/"},
+	"sc":               {"https://rdap.identitydigital.services/rdap/"},
+	"sh":               {"https://rdap.identitydigital.services/rdap/"},
+	"sk":               {"https://rdap.sk-nic.sk/sk/"},
+	"so":               {"https://rdap.nic.so/"},
+	"td":               {"https://rdap.nic.td/"},
+	"tl":               {"https://rdap.nic.tl/"},
+	"us":               {"https://rdap.nic.us/"},
+	"vc":               {"https://rdap.identitydigital.services/rdap/"},
+	"ve":               {"https://rdap.nic.ve/rdap/"},
+	"vu":               {"https://rdap.dnrs.vu/"},
+	"ws":               {"https://rdap.website.ws/"},
+	"xn--mgbcpq6gpa1a": {"https://rdap.centralnic.com/xn--mgbcpq6gpa1a/"}, // Bahrain IDN
+	"xn--p1ai":         {"https://cctld.ru/tci-ripn-rdap/"},               // Cyrillic .rf
+}
+
 // bootstrap resolves a TLD to its RDAP base URLs using the IANA registry, which it
 // fetches once and refreshes lazily.
 type bootstrap struct {
@@ -100,6 +149,11 @@ func (b *bootstrap) fetch(ctx context.Context) error {
 	}
 	if len(services) == 0 {
 		return fmt.Errorf("%w: empty bootstrap registry", srcerr.ErrUpstream)
+	}
+	for tld, urls := range seeds {
+		if _, ok := services[tld]; !ok {
+			services[tld] = urls
+		}
 	}
 
 	b.mu.Lock()

--- a/internal/rdap/bootstrap_test.go
+++ b/internal/rdap/bootstrap_test.go
@@ -1,0 +1,49 @@
+package rdap
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestSeedsAreSane(t *testing.T) {
+	for tld, urls := range seeds {
+		if tld != strings.ToLower(tld) || len(urls) == 0 {
+			t.Errorf("seed %q: TLDs are lowercase and need at least one URL", tld)
+		}
+		for _, u := range urls {
+			if !strings.HasPrefix(u, "https://") || !strings.HasSuffix(u, "/") {
+				t.Errorf("seed %q: %q must be https and end with /", tld, u)
+			}
+		}
+	}
+}
+
+func TestBootstrapSeeds(t *testing.T) {
+	// Fake IANA registry: knows com, and claims ch (so the seed must lose).
+	iana := `{"services":[[["com"],["https://rdap.verisign.com/com/v1/"]],[["ch"],["https://iana.example/"]]]}`
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write([]byte(iana))
+	}))
+	defer ts.Close()
+
+	b := newBootstrap(ts.Client())
+	b.url = ts.URL
+
+	tests := []struct{ domain, want string }{
+		{"vaduz.li", "https://rdap.nic.li/"},                 // seed fills the gap
+		{"nic.ch", "https://iana.example/"},                  // IANA outranks the seed
+		{"example.com", "https://rdap.verisign.com/com/v1/"}, // business as usual
+	}
+	for _, tt := range tests {
+		urls, err := b.serversFor(context.Background(), tt.domain)
+		if err != nil {
+			t.Fatalf("%s: %v", tt.domain, err)
+		}
+		if urls[0] != tt.want {
+			t.Errorf("%s = %q, want %q", tt.domain, urls[0], tt.want)
+		}
+	}
+}

--- a/internal/rdap/client.go
+++ b/internal/rdap/client.go
@@ -53,9 +53,16 @@ func (c *Client) Lookup(ctx context.Context, n domain.Name) (*model.Result, erro
 	}
 
 	base := strings.TrimRight(servers[0], "/")
-	url := base + "/domain/" + n.ASCII
+	r, err := c.get(ctx, n, base)
+	if err != nil {
+		return nil, &srcerr.SourceError{Source: model.SourceRDAP, Server: base, Err: err}
+	}
+	return r, nil
+}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+// get fetches and maps the domain object from the RDAP server at base.
+func (c *Client) get(ctx context.Context, n domain.Name, base string) (*model.Result, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, base+"/domain/"+n.ASCII, nil)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", srcerr.ErrUpstream, err)
 	}

--- a/internal/rdap/map.go
+++ b/internal/rdap/map.go
@@ -13,7 +13,7 @@ import (
 
 // rdapDomain is the subset of an RFC 9083 domain object that we map.
 type rdapDomain struct {
-	Handle      string           `json:"handle"`
+	Handle      laxString        `json:"handle"`
 	LDHName     string           `json:"ldhName"`
 	UnicodeName string           `json:"unicodeName"`
 	Port43      string           `json:"port43"`
@@ -30,7 +30,7 @@ type rdapEvent struct {
 }
 
 type rdapEntity struct {
-	Handle    string         `json:"handle"`
+	Handle    laxString      `json:"handle"`
 	Roles     []string       `json:"roles"`
 	PublicIDs []rdapPublicID `json:"publicIds"`
 	VCard     vcard          `json:"vcardArray"`
@@ -39,8 +39,24 @@ type rdapEntity struct {
 }
 
 type rdapPublicID struct {
-	Type       string `json:"type"`
-	Identifier string `json:"identifier"`
+	Type       string    `json:"type"`
+	Identifier laxString `json:"identifier"`
+}
+
+// laxString accepts both "1234" and 1234; some alpha-grade registries can't decide.
+type laxString string
+
+func (s *laxString) UnmarshalJSON(b []byte) error {
+	if len(b) > 0 && b[0] == '"' {
+		var v string
+		if err := json.Unmarshal(b, &v); err != nil {
+			return err
+		}
+		*s = laxString(v)
+	} else if string(b) != "null" {
+		*s = laxString(b)
+	}
+	return nil
 }
 
 type rdapLink struct {
@@ -75,7 +91,7 @@ func mapDomain(n domain.Name, server string, raw []byte) (*model.Result, error) 
 
 	r := model.New(n.ASCII, n.ASCII, n.TLD)
 	r.IsRegistered = true
-	r.ID = model.Str(d.Handle)
+	r.ID = model.Str(string(d.Handle))
 	r.Status = model.NormalizeStatuses(d.Status)
 	r.Meta = model.Meta{Source: model.SourceRDAP, Server: model.Str(server), FetchedAt: time.Now().UTC()}
 	r.Raw = raw
@@ -173,7 +189,7 @@ func mapRegistrar(r *model.Result, e rdapEntity) {
 	r.Registrar.Name = model.Str(e.VCard.fn)
 	for _, id := range e.PublicIDs {
 		if strings.Contains(strings.ToLower(id.Type), "iana") {
-			r.Registrar.IANAID = model.Str(id.Identifier)
+			r.Registrar.IANAID = model.Str(string(id.Identifier))
 		}
 	}
 	for _, l := range e.Links {

--- a/internal/rdap/map.go
+++ b/internal/rdap/map.go
@@ -38,6 +38,15 @@ type rdapEntity struct {
 	Links     []rdapLink     `json:"links"`
 }
 
+// TWNIC pads entities arrays with bare 404s; skip anything that is not an object.
+func (e *rdapEntity) UnmarshalJSON(b []byte) error {
+	if len(b) == 0 || b[0] != '{' {
+		return nil
+	}
+	type plain rdapEntity
+	return json.Unmarshal(b, (*plain)(e))
+}
+
 type rdapPublicID struct {
 	Type       string    `json:"type"`
 	Identifier laxString `json:"identifier"`

--- a/internal/server/errors.go
+++ b/internal/server/errors.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"strconv"
+	"time"
 
 	"github.com/lissy93/who-dat/internal/domain"
 	"github.com/lissy93/who-dat/internal/srcerr"
@@ -28,6 +29,9 @@ type errorDetail struct {
 	Code    string `json:"code"`
 	Message string `json:"message"`
 	Query   string `json:"query"`
+	Source  string `json:"source,omitempty"` // lookup backend that failed: "rdap" or "whois"
+	Server  string `json:"server,omitempty"` // upstream server queried, when known
+	Detail  string `json:"detail,omitempty"` // underlying error chain, for diagnostics
 }
 
 // writeError sends the standard error envelope with the given status.
@@ -45,22 +49,40 @@ func writeDomainError(w http.ResponseWriter, err error, query string) {
 	}
 }
 
-// writeLookupError maps an orchestrator/source error to the right status and envelope.
-func writeLookupError(w http.ResponseWriter, err error, query string) {
+// lookupError sorts a lookup failure into status + envelope, naming the failing
+// source, server, and underlying detail when known.
+func lookupError(err error, query string) (status int, retryAfter time.Duration, d errorDetail) {
+	d = errorDetail{Query: query, Detail: err.Error()}
+	var se *srcerr.SourceError
+	if errors.As(err, &se) {
+		d.Source, d.Server = se.Source, se.Server
+	}
+
 	var rl *srcerr.RateLimited
 	switch {
 	case errors.As(err, &rl):
-		if rl.RetryAfter > 0 {
-			w.Header().Set("Retry-After", strconv.Itoa(int(rl.RetryAfter.Seconds())))
-		}
-		writeError(w, http.StatusTooManyRequests, codeRateLimited, "rate limited; retry later", query)
+		d.Code, d.Message = codeRateLimited, "rate limited; retry later"
+		return http.StatusTooManyRequests, rl.RetryAfter, d
 	case errors.Is(err, srcerr.ErrTimeout), errors.Is(err, context.DeadlineExceeded):
-		writeError(w, http.StatusGatewayTimeout, codeUpstreamTimout, "registry timed out", query)
+		d.Code, d.Message = codeUpstreamTimout, "registry timed out"
+		return http.StatusGatewayTimeout, 0, d
 	case errors.Is(err, srcerr.ErrNoSource):
-		writeError(w, http.StatusNotImplemented, codeUnsupportedTLD, "no rdap or whois source for this tld", query)
+		d.Code, d.Message = codeUnsupportedTLD, "no rdap or whois source for this tld"
+		return http.StatusNotImplemented, 0, d
 	case errors.Is(err, srcerr.ErrUpstream):
-		writeError(w, http.StatusBadGateway, codeUpstreamError, "registry unreachable or returned an invalid response", query)
+		d.Code, d.Message = codeUpstreamError, "registry unreachable or returned an invalid response"
+		return http.StatusBadGateway, 0, d
 	default:
-		writeError(w, http.StatusInternalServerError, codeInternal, "internal error", query)
+		d.Code, d.Message, d.Detail = codeInternal, "internal error", "" // internals stay internal
+		return http.StatusInternalServerError, 0, d
 	}
+}
+
+// writeLookupError maps an orchestrator/source error to the right status and envelope.
+func writeLookupError(w http.ResponseWriter, err error, query string) {
+	status, retryAfter, d := lookupError(err, query)
+	if retryAfter > 0 {
+		w.Header().Set("Retry-After", strconv.Itoa(int(retryAfter.Seconds())))
+	}
+	writeJSON(w, status, errorBody{Error: d})
 }

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -81,7 +81,8 @@ func (s *server) handleMulti(w http.ResponseWriter, r *http.Request) {
 		}
 		res, err := s.svc.Lookup(ctx, n)
 		if err != nil {
-			results = append(results, multiError(q, "lookup failed"))
+			_, _, d := lookupError(err, q)
+			results = append(results, errorBody{Error: d})
 			cacheable = false
 			continue
 		}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -34,6 +34,7 @@ func Build(cfg *config.Config) http.Handler {
 			IdleConnTimeout:     90 * time.Second,
 			TLSHandshakeTimeout: 10 * time.Second,
 			TLSClientConfig:     rdap.TLSConfig(),
+			ForceAttemptHTTP2:   true, // custom TLS config turns h2 off; some registries demand it
 		},
 	}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -3,8 +3,11 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/lissy93/who-dat/internal/config"
@@ -72,6 +75,57 @@ func TestLookupStatusCodes(t *testing.T) {
 				if body.Error.Code != tt.wantCode {
 					t.Errorf("error code = %q, want %q", body.Error.Code, tt.wantCode)
 				}
+			}
+		})
+	}
+}
+
+func TestLookupErrorEnvelope(t *testing.T) {
+	tests := []struct {
+		name                             string
+		rdapErr, whoisErr                error
+		wantStatus                       int
+		wantCode, wantSource, wantServer string
+		wantDetail                       string // substring; empty means detail must be empty
+	}{
+		{
+			name:     "source and server surface",
+			rdapErr:  &srcerr.SourceError{Source: model.SourceRDAP, Server: "https://rdap.nic.li", Err: fmt.Errorf("%w: no response", srcerr.ErrTimeout)},
+			whoisErr: srcerr.ErrNoSource, wantStatus: http.StatusGatewayTimeout, wantCode: codeUpstreamTimout,
+			wantSource: model.SourceRDAP, wantServer: "https://rdap.nic.li", wantDetail: "no response",
+		},
+		{
+			name:       "fallback explains missing rdap",
+			rdapErr:    srcerr.ErrNoSource,
+			whoisErr:   &srcerr.SourceError{Source: model.SourceWhois, Err: fmt.Errorf("%w: i/o timeout", srcerr.ErrTimeout)},
+			wantStatus: http.StatusGatewayTimeout, wantCode: codeUpstreamTimout,
+			wantSource: model.SourceWhois, wantDetail: "no rdap server registered for .com",
+		},
+		{
+			name: "internal errors keep quiet", rdapErr: errors.New("secret internals"),
+			whoisErr: srcerr.ErrNoSource, wantStatus: http.StatusInternalServerError, wantCode: codeInternal,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc := lookup.NewService(&fakeSource{err: tt.rdapErr}, &fakeSource{err: tt.whoisErr}, nil)
+			rec := httptest.NewRecorder()
+			New(&config.Config{LookupTimeout: 2_000_000_000, MaxDomains: 5}, svc).
+				ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/v1/whois/example.com", nil))
+
+			var body errorBody
+			if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			e := body.Error
+			if rec.Code != tt.wantStatus || e.Code != tt.wantCode {
+				t.Fatalf("status/code = %d/%q, want %d/%q", rec.Code, e.Code, tt.wantStatus, tt.wantCode)
+			}
+			if e.Source != tt.wantSource || e.Server != tt.wantServer {
+				t.Errorf("source/server = %q/%q, want %q/%q", e.Source, e.Server, tt.wantSource, tt.wantServer)
+			}
+			if !strings.Contains(e.Detail, tt.wantDetail) || (tt.wantDetail == "" && e.Detail != "") {
+				t.Errorf("detail = %q, want %q", e.Detail, tt.wantDetail)
 			}
 		})
 	}

--- a/internal/srcerr/srcerr.go
+++ b/internal/srcerr/srcerr.go
@@ -18,6 +18,23 @@ var ErrUpstream = errors.New("upstream registry error")
 // ErrTimeout means the registry did not respond in time. Maps to 504.
 var ErrTimeout = errors.New("upstream registry timed out")
 
+// SourceError tags an error with the backend that raised it and, when known, the
+// server queried, so API errors can say exactly who let us down.
+type SourceError struct {
+	Source string // "rdap" or "whois"
+	Server string // empty when unknown
+	Err    error
+}
+
+func (e *SourceError) Error() string {
+	if e.Server != "" {
+		return fmt.Sprintf("%s %s: %v", e.Source, e.Server, e.Err)
+	}
+	return fmt.Sprintf("%s: %v", e.Source, e.Err)
+}
+
+func (e *SourceError) Unwrap() error { return e.Err }
+
 // RateLimited wraps an upstream (or local) rate-limit signal. Maps to 429.
 type RateLimited struct {
 	RetryAfter time.Duration

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -66,7 +66,8 @@
               .then(async (response) => {
                 const data = await response.json();
                 if (!response.ok) {
-                  throw new Error((data && data.error && data.error.message) || 'Lookup failed');
+                  const e = data && data.error;
+                  throw new Error(e ? [e.message, e.detail].filter(Boolean).join(' - ') : 'Lookup failed');
                 }
                 return data;
               })

--- a/internal/web/static/openapi.yaml
+++ b/internal/web/static/openapi.yaml
@@ -109,6 +109,9 @@ components:
             code: { type: string, example: INVALID_DOMAIN }
             message: { type: string }
             query: { type: string }
+            source: { type: string, enum: [rdap, whois], description: Lookup backend that failed, when known. }
+            server: { type: string, description: Upstream server queried, when known. }
+            detail: { type: string, description: Underlying error detail, for diagnostics. }
     Result:
       type: object
       properties:

--- a/internal/whois/whois.go
+++ b/internal/whois/whois.go
@@ -23,6 +23,16 @@ func NewClient() *Client { return &Client{} }
 
 // Lookup queries WHOIS for n, honoring ctx cancellation/deadline
 func (c *Client) Lookup(ctx context.Context, n domain.Name) (*model.Result, error) {
+	r, err := c.query(ctx, n)
+	if err != nil {
+		return nil, &srcerr.SourceError{Source: model.SourceWhois, Err: err}
+	}
+	return r, nil
+}
+
+// query runs the blocking WHOIS lookup. The lib picks the server itself, so we never
+// learn which host we actually asked.
+func (c *Client) query(ctx context.Context, n domain.Name) (*model.Result, error) {
 	type result struct {
 		raw string
 		err error


### PR DESCRIPTION
- When we can't find a TLDs RDAP server from IANA, there's now a fallback seed, of known good RDAP servers from certain TLDs which anre't yet submitted to IANA.
- Error response now gets better and more specific error message
- Improves rdap mapping robustness and enables http/2 for outgoing rdap and whois reqs

