### PR TITLE
feat: map dates and resistrar from SWITCH payloads

### DIFF
--- a/internal/rdap/map.go
+++ b/internal/rdap/map.go
@@ -36,6 +36,7 @@ type rdapEntity struct {
 	VCard     vcard          `json:"vcardArray"`
 	Entities  []rdapEntity   `json:"entities"`
 	Links     []rdapLink     `json:"links"`
+	URL       string         `json:"url"` // nonstandard, but SWITCH puts the registrar URL here
 }
 
 // TWNIC pads entities arrays with bare 404s; skip anything that is not an object.
@@ -121,10 +122,25 @@ func mapDomain(n domain.Name, server string, raw []byte) (*model.Result, error) 
 	return r, nil
 }
 
+// eventDateLayouts covers what registries actually emit: RFC 9083 mandates RFC 3339,
+// but some (e.g. SWITCH for .ch/.li) send zoneless timestamps or bare dates.
+var eventDateLayouts = []string{time.RFC3339, "2006-01-02T15:04:05", "2006-01-02"}
+
+// parseEventDate parses an RDAP event date leniently; zero time means unparseable.
+func parseEventDate(s string) time.Time {
+	s = strings.TrimSpace(s)
+	for _, layout := range eventDateLayouts {
+		if t, err := time.Parse(layout, s); err == nil {
+			return t
+		}
+	}
+	return time.Time{}
+}
+
 func mapEvents(r *model.Result, events []rdapEvent) {
 	for _, e := range events {
-		t, err := time.Parse(time.RFC3339, e.Date)
-		if err != nil {
+		t := parseEventDate(e.Date)
+		if t.IsZero() {
 			continue
 		}
 		switch strings.ToLower(e.Action) {
@@ -195,7 +211,7 @@ func mapEntities(r *model.Result, entities []rdapEntity) {
 }
 
 func mapRegistrar(r *model.Result, e rdapEntity) {
-	r.Registrar.Name = model.Str(e.VCard.fn)
+	r.Registrar.Name = model.Str(e.VCard.name())
 	for _, id := range e.PublicIDs {
 		if strings.Contains(strings.ToLower(id.Type), "iana") {
 			r.Registrar.IANAID = model.Str(string(id.Identifier))
@@ -205,6 +221,9 @@ func mapRegistrar(r *model.Result, e rdapEntity) {
 		if strings.EqualFold(l.Rel, "about") || (r.Registrar.URL == nil && strings.HasPrefix(l.Href, "http")) {
 			r.Registrar.URL = model.Str(l.Href)
 		}
+	}
+	if r.Registrar.URL == nil && strings.HasPrefix(e.URL, "http") {
+		r.Registrar.URL = model.Str(e.URL)
 	}
 	for _, sub := range e.Entities {
 		for _, role := range sub.Roles {

--- a/internal/rdap/map_test.go
+++ b/internal/rdap/map_test.go
@@ -18,6 +18,28 @@ var update = flag.Bool("update", false, "update golden files")
 // goldenCases maps a frozen RDAP fixture to the domain it represents.
 var goldenCases = map[string]domain.Name{
 	"example.com.json": {ASCII: "example.com", Unicode: "example.com", TLD: "com"},
+	"vaduz.li.json":    {ASCII: "vaduz.li", Unicode: "vaduz.li", TLD: "li"}, // SWITCH: bare event dates, org-only registrar vcard
+}
+
+func TestParseEventDate(t *testing.T) {
+	cases := map[string]string{
+		"2021-03-09T14:30:00Z":      "2021-03-09T14:30:00Z",
+		"2021-03-09T14:30:00+02:00": "2021-03-09T12:30:00Z",
+		"2021-03-09T14:30:00":       "2021-03-09T14:30:00Z",
+		"1997-06-24":                "1997-06-24T00:00:00Z",
+		" 1997-06-24 ":              "1997-06-24T00:00:00Z",
+		"24.06.1997":                "",
+		"":                          "",
+	}
+	for in, want := range cases {
+		got := ""
+		if t2 := parseEventDate(in); !t2.IsZero() {
+			got = t2.UTC().Format(time.RFC3339)
+		}
+		if got != want {
+			t.Errorf("parseEventDate(%q) = %q, want %q", in, got, want)
+		}
+	}
 }
 
 func TestMapDomainGolden(t *testing.T) {

--- a/internal/rdap/testdata/vaduz.li.golden.json
+++ b/internal/rdap/testdata/vaduz.li.golden.json
@@ -1,0 +1,118 @@
+{
+  "query": "vaduz.li",
+  "domain": "vaduz.li",
+  "domainUnicode": null,
+  "id": "vaduz.li",
+  "tld": "li",
+  "isRegistered": true,
+  "registrar": {
+    "name": "Swizzonic AG",
+    "ianaId": null,
+    "url": "https://www.swizzonic.ch/company/kontaktiere-uns/",
+    "whoisServer": null,
+    "abuseEmail": null,
+    "abusePhone": null,
+    "reseller": null
+  },
+  "status": [
+    "ok"
+  ],
+  "nameservers": [
+    {
+      "name": "pdns1.llv.li",
+      "ipv4": [
+        "193.222.114.66"
+      ],
+      "ipv6": []
+    },
+    {
+      "name": "pdns.llv.li",
+      "ipv4": [
+        "193.222.114.65"
+      ],
+      "ipv6": []
+    },
+    {
+      "name": "scsnms.switch.ch",
+      "ipv4": [
+        "130.59.31.26"
+      ],
+      "ipv6": [
+        "2001:620:0:ff::a7"
+      ]
+    }
+  ],
+  "dnssec": {
+    "signed": false,
+    "dsData": []
+  },
+  "dates": {
+    "created": "1997-06-24T00:00:00Z",
+    "updated": null,
+    "expires": null
+  },
+  "contacts": {
+    "registrant": {
+      "name": null,
+      "organization": null,
+      "email": null,
+      "phone": null,
+      "address": {
+        "street": null,
+        "city": null,
+        "state": null,
+        "postalCode": null,
+        "country": null
+      },
+      "redacted": true
+    },
+    "admin": {
+      "name": null,
+      "organization": null,
+      "email": null,
+      "phone": null,
+      "address": {
+        "street": null,
+        "city": null,
+        "state": null,
+        "postalCode": null,
+        "country": null
+      },
+      "redacted": true
+    },
+    "tech": {
+      "name": null,
+      "organization": null,
+      "email": null,
+      "phone": null,
+      "address": {
+        "street": null,
+        "city": null,
+        "state": null,
+        "postalCode": null,
+        "country": null
+      },
+      "redacted": true
+    },
+    "billing": {
+      "name": null,
+      "organization": null,
+      "email": null,
+      "phone": null,
+      "address": {
+        "street": null,
+        "city": null,
+        "state": null,
+        "postalCode": null,
+        "country": null
+      },
+      "redacted": true
+    }
+  },
+  "meta": {
+    "source": "rdap",
+    "server": "https://rdap.example/",
+    "fetchedAt": "0001-01-01T00:00:00Z",
+    "cached": false
+  }
+}

--- a/internal/rdap/testdata/vaduz.li.json
+++ b/internal/rdap/testdata/vaduz.li.json
@@ -1,0 +1,118 @@
+{
+    "rdapConformance": [
+        "rdap_level_0"
+    ],
+    "notices": [
+        {
+            "title": "Acceptable Use Policy (AUP)",
+            "description": [
+                "This information is subject to an Acceptable Use Policy."
+            ],
+            "links": [
+                {
+                    "rel": "alternate",
+                    "type": "text/html",
+                    "href": "https://www.nic.ch/terms/aup/"
+                }
+            ]
+        }
+    ],
+    "objectClassName": "domain",
+    "ldhName": "vaduz.li",
+    "switch_name": "vaduz.li",
+    "handle": "vaduz.li",
+    "entities": [
+        {
+            "objectClassName": "entity",
+            "roles": [
+                "registrar"
+            ],
+            "vcardArray": [
+                "vcard",
+                [
+                    [
+                        "version",
+                        {
+                        },
+                        "text",
+                        "4.0"
+                    ],
+                    [
+                        "org",
+                        {
+                        },
+                        "text",
+                        "Swizzonic AG"
+                    ],
+                    [
+                        "adr",
+                        {
+                        },
+                        "text",
+                        [
+                            "",
+                            "",
+                            "Badenerstrasse 47",
+                            "Zürich",
+                            "",
+                            "8004",
+                            "CH"
+                        ]
+                    ],
+                    [
+                        "kind",
+                        {
+                        },
+                        "text",
+                        "group"
+                    ]
+                ]
+            ],
+            "url": "https://www.swizzonic.ch/company/kontaktiere-uns/"
+        }
+    ],
+    "status": [
+        "active"
+    ],
+    "events": [
+        {
+            "eventAction": "registration",
+            "eventDate": "1997-06-24"
+        }
+    ],
+    "secureDNS": {
+        "delegationSigned": false
+    },
+    "nameservers": [
+        {
+            "ldhName": "pdns1.llv.li",
+            "objectClassName": "nameserver",
+            "ipAddresses": {
+                "v4": [
+                    "193.222.114.66"
+                ]
+            }
+        },
+        {
+            "ldhName": "pdns.llv.li",
+            "objectClassName": "nameserver",
+            "ipAddresses": {
+                "v4": [
+                    "193.222.114.65"
+                ]
+            }
+        },
+        {
+            "ldhName": "scsnms.switch.ch",
+            "objectClassName": "nameserver",
+            "ipAddresses": {
+                "v4": [
+                    "130.59.31.26"
+                ],
+                "v6": [
+                    "2001:620:0:ff::a7"
+                ]
+            }
+        }
+    ]
+}

--- a/internal/rdap/vcard.go
+++ b/internal/rdap/vcard.go
@@ -56,6 +56,14 @@ func (v *vcard) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+// name returns the display name, falling back to org when fn is absent (e.g. SWITCH).
+func (v *vcard) name() string {
+	if v.fn != "" {
+		return v.fn
+	}
+	return v.org
+}
+
 // address maps the jCard ADR components onto the model address.
 func (v *vcard) address() model.Address {
 	at := func(i int) *string {


### PR DESCRIPTION
SWITCH's RDAP server emits bare dates and org-only jCards. So this PR attempts to parse and normalize these to normal RFC 3339 dates