### PR TITLE
fix: restrict bare domain lookups to GET

### DIFF
--- a/internal/server/errors.go
+++ b/internal/server/errors.go
@@ -13,12 +13,13 @@ import (
 
 // Error codes returned in the error envelope.
 const (
-	codeInvalidDomain  = "INVALID_DOMAIN"
-	codeUnsupportedTLD = "UNSUPPORTED_TLD"
-	codeRateLimited    = "RATE_LIMITED"
-	codeUpstreamError  = "UPSTREAM_ERROR"
-	codeUpstreamTimout = "UPSTREAM_TIMEOUT"
-	codeInternal       = "INTERNAL_ERROR"
+	codeInvalidDomain    = "INVALID_DOMAIN"
+	codeUnsupportedTLD   = "UNSUPPORTED_TLD"
+	codeRateLimited      = "RATE_LIMITED"
+	codeMethodNotAllowed = "METHOD_NOT_ALLOWED"
+	codeUpstreamError    = "UPSTREAM_ERROR"
+	codeUpstreamTimout   = "UPSTREAM_TIMEOUT"
+	codeInternal         = "INTERNAL_ERROR"
 )
 
 type errorBody struct {

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -124,6 +124,11 @@ func (s *server) handleRoot(w http.ResponseWriter, r *http.Request) {
 		s.files.ServeHTTP(w, r)
 		return
 	}
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", http.MethodGet)
+		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+		return
+	}
 	s.lookupAPI.ServeHTTP(w, r)
 }
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -124,8 +124,8 @@ func (s *server) handleRoot(w http.ResponseWriter, r *http.Request) {
 		s.files.ServeHTTP(w, r)
 		return
 	}
-	if r.Method != http.MethodGet {
-		w.Header().Set("Allow", http.MethodGet)
+	if r.Method != http.MethodGet && r.Method != http.MethodHead {
+		w.Header().Set("Allow", "GET, HEAD")
 		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
 		return
 	}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -125,8 +125,8 @@ func (s *server) handleRoot(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if r.Method != http.MethodGet && r.Method != http.MethodHead {
-		w.Header().Set("Allow", "GET, HEAD")
-		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
+		w.Header().Set("Allow", "GET, HEAD, OPTIONS")
+		writeError(w, http.StatusMethodNotAllowed, codeMethodNotAllowed, "method not allowed", "")
 		return
 	}
 	s.lookupAPI.ServeHTTP(w, r)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -258,11 +258,19 @@ func TestMultiCacheHeader(t *testing.T) {
 	}
 }
 
-func TestBareLookupRejectsPost(t *testing.T) {
+func TestBareLookupMethods(t *testing.T) {
+	h := newTestServer(registered(), nil)
+
 	rec := httptest.NewRecorder()
-	newTestServer(registered(), nil).ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/example.com", nil))
-	if rec.Code != http.StatusMethodNotAllowed {
-		t.Fatalf("status = %d, want %d", rec.Code, http.StatusMethodNotAllowed)
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/example.com", nil))
+	if rec.Code != http.StatusMethodNotAllowed || rec.Header().Get("Allow") != "GET, HEAD" {
+		t.Fatalf("POST status/allow = %d/%q, want 405/%q", rec.Code, rec.Header().Get("Allow"), "GET, HEAD")
+	}
+
+	rec = httptest.NewRecorder()
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodHead, "/example.com", nil))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("HEAD status = %d, want 200", rec.Code)
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -258,6 +258,14 @@ func TestMultiCacheHeader(t *testing.T) {
 	}
 }
 
+func TestBareLookupRejectsPost(t *testing.T) {
+	rec := httptest.NewRecorder()
+	newTestServer(registered(), nil).ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/example.com", nil))
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("status = %d, want %d", rec.Code, http.StatusMethodNotAllowed)
+	}
+}
+
 func TestHealth(t *testing.T) {
 	rec := httptest.NewRecorder()
 	newTestServer(nil, nil).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -263,8 +263,12 @@ func TestBareLookupMethods(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, httptest.NewRequest(http.MethodPost, "/example.com", nil))
-	if rec.Code != http.StatusMethodNotAllowed || rec.Header().Get("Allow") != "GET, HEAD" {
-		t.Fatalf("POST status/allow = %d/%q, want 405/%q", rec.Code, rec.Header().Get("Allow"), "GET, HEAD")
+	if rec.Code != http.StatusMethodNotAllowed || rec.Header().Get("Allow") != "GET, HEAD, OPTIONS" {
+		t.Fatalf("POST status/allow = %d/%q, want 405/%q", rec.Code, rec.Header().Get("Allow"), "GET, HEAD, OPTIONS")
+	}
+	var body errorBody
+	if err := json.Unmarshal(rec.Body.Bytes(), &body); err != nil || body.Error.Code != codeMethodNotAllowed {
+		t.Fatalf("POST body = %s, want %s error", rec.Body, codeMethodNotAllowed)
 	}
 
 	rec = httptest.NewRecorder()

--- a/internal/web/static/openapi.yaml
+++ b/internal/web/static/openapi.yaml
@@ -45,6 +45,7 @@ paths:
           content:
             application/json:
               schema: { $ref: "#/components/schemas/Result" }
+        "405": { $ref: "#/components/responses/Error" }
   /multi:
     get:
       summary: Look up multiple domains


### PR DESCRIPTION
The bare `/{domain}` shortcut was accepting POST requests and running the lookup, even though the endpoint is documented as GET-only. This returns `405 Method Not Allowed` for other methods, matching the canonical route.

Tested with `go test -race -shuffle=on ./...`, `go vet ./...`, and `go build ./...`.