### PR TITLE
fix: allow X-API-Key through CORS preflight

### DIFF
--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -72,7 +72,7 @@ func cors(next http.Handler) http.Handler {
 		h := w.Header()
 		h.Set("Access-Control-Allow-Origin", "*")
 		h.Set("Access-Control-Allow-Methods", "GET, OPTIONS")
-		h.Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
+		h.Set("Access-Control-Allow-Headers", "Authorization, Content-Type, X-API-Key")
 		if r.Method == http.MethodOptions {
 			w.WriteHeader(http.StatusNoContent)
 			return

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -278,6 +278,30 @@ func TestBareLookupMethods(t *testing.T) {
 	}
 }
 
+func TestPreflightAllowsAuthHeaders(t *testing.T) {
+	r := httptest.NewRequest(http.MethodOptions, "/example.com", nil)
+	r.Header.Set("Origin", "https://app.example")
+	r.Header.Set("Access-Control-Request-Method", "GET")
+	r.Header.Set("Access-Control-Request-Headers", "x-api-key")
+	rec := httptest.NewRecorder()
+	newTestServer(registered(), nil).ServeHTTP(rec, r)
+
+	if rec.Code != http.StatusNoContent {
+		t.Fatalf("preflight status = %d, want 204", rec.Code)
+	}
+	// Every header tokenFrom reads must survive preflight, or browsers can't send it.
+	header := rec.Header().Get("Access-Control-Allow-Headers")
+	allowed := map[string]bool{}
+	for _, h := range strings.Split(header, ",") {
+		allowed[strings.ToLower(strings.TrimSpace(h))] = true
+	}
+	for _, want := range []string{"authorization", "x-api-key"} {
+		if !allowed[want] {
+			t.Errorf("Access-Control-Allow-Headers = %q, want it to include %s", header, want)
+		}
+	}
+}
+
 func TestHealth(t *testing.T) {
 	rec := httptest.NewRecorder()
 	newTestServer(nil, nil).ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/health", nil))


### PR DESCRIPTION
`tokenFrom` takes the key from either `Authorization: Bearer` or `X-API-Key`, but the preflight only advertises `Authorization, Content-Type`. So `X-API-Key` works fine from curl and gets blocked in the browser before the request is even sent - it's not on the CORS safelist, so it has to be named in `Access-Control-Allow-Headers` to get through.

Ran into it on a self-hosted instance with `AUTH_KEY` set, calling it from a little frontend on anohter origin.

```bash
# the server takes the header happily
curl -o /dev/null -w '%{http_code}\n' localhost:8080/example.com -H 'X-API-Key: secret123'  # 200
curl -o /dev/null -w '%{http_code}\n' localhost:8080/example.com                            # 401

# but the preflight says you can't send it
curl -si -X OPTIONS localhost:8080/example.com -H 'Origin: https://app.example' \
  -H 'Access-Control-Request-Method: GET' -H 'Access-Control-Request-Headers: x-api-key'
# Access-Control-Allow-Headers: Authorization, Content-Type
```

Left `Access-Control-Allow-Methods` alone even though `handleRoot` answers `Allow: GET, HEAD, OPTIONS` now - HEAD is safelisted so nothing's actually broken there. Happy to add it if you'd rather the two matched, and equally happy to drop this if `X-API-Key` is meant to be non-browser only.
