### PR TITLE
fix: give the rate limiter a minimum burst of one

### DIFF
--- a/internal/server/middleware.go
+++ b/internal/server/middleware.go
@@ -166,6 +166,9 @@ type bucket struct {
 }
 
 func newLimiter(ratePerSec float64, burst int) *limiter {
+	if burst < 1 {
+		burst = 1 // refills clamp to the burst, so a zero bucket never admits a second request
+	}
 	l := &limiter{buckets: make(map[string]*bucket), rate: ratePerSec, burst: float64(burst)}
 	go l.sweep()
 	return l

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/lissy93/who-dat/internal/config"
 	"github.com/lissy93/who-dat/internal/domain"
@@ -217,6 +218,20 @@ func TestValidKeyBypassesRateLimit(t *testing.T) {
 	}
 	if !throttled {
 		t.Fatal("wrong key was never throttled; bypass is too permissive")
+	}
+}
+
+// RATE_BURST is 0 unless it is set or we're on Vercel, so RATE_PER_MINUTE on its own
+// leaves the bucket nothing to refill into and only the first request ever gets in.
+func TestRateLimitWithoutBurst(t *testing.T) {
+	lim := newLimiter(1_000_000, 0) // a token per µs, so a 1ms gap always refills one
+	for i := 0; i < 3; i++ {
+		if i > 0 {
+			time.Sleep(time.Millisecond)
+		}
+		if ok, retry := lim.allow("192.0.2.4"); !ok {
+			t.Fatalf("request %d refused with retry-after %ds, want allowed", i, retry)
+		}
 	}
 }
 


### PR DESCRIPTION
Setting `RATE_PER_MINUTE` on its own gets you an API that answers exactly one request and then 429s everything after it. `RATE_BURST` is 0 unless you're on Vercel or set it yourself, and the refill in `allow()` clamps to the burst, so the bucket can never climb back up to a whole token. The `Retry-After` that comes with the 429 is wrong too, waiting doesnt help.

```bash
RATE_PER_MINUTE=60 ./who-dat

curl -s -o /dev/null -w '%{http_code}\n' localhost:8080/example.com   # 200
sleep 30
curl -s -o /dev/null -w '%{http_code}\n' localhost:8080/example.com   # 429
```

Vercel defaults the burst to 10, and self-hosting has the limiter off unless you turn it on, so I don't think this would show up on a normal deploy.

I put the floor in `newLimiter` rather than defaulting `RATE_BURST` in `Load()`, beacuse `intEnv` can't tell an unset var from an explicit `0`, and your off-Vercel test pins that pair to 0/0. With it, `RATE_PER_MINUTE=60` and no burst gives a sustained 60/min, and rapid-fire still gets throttled.
